### PR TITLE
add(remove_tooltip_for_help_icon)[OASIS-3278]

### DIFF
--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -3,6 +3,8 @@ import React from 'react';
 
 import icons from './icons.json';
 
+const HELP_ICON_TITLE = 'help';
+
 const propTypes = {
   description: PropTypes.string,
   fill: PropTypes.string,
@@ -86,6 +88,9 @@ const Icon = ({
     <svg
       data-oui-component={ true }
       {...props}>
+      { icon.title !== HELP_ICON_TITLE && (
+          <title>{icon.title}</title>
+      ) }
       <desc>{ description }</desc>
       { content }
     </svg>

--- a/src/Icon/index.js
+++ b/src/Icon/index.js
@@ -86,7 +86,6 @@ const Icon = ({
     <svg
       data-oui-component={ true }
       {...props}>
-      <title>{icon.title}</title>
       <desc>{ description }</desc>
       { content }
     </svg>

--- a/src/Icon/index.test.js
+++ b/src/Icon/index.test.js
@@ -76,6 +76,14 @@ describe('<Icon/> Component', () => {
       />);
     expect(component.contains(<title>ab</title>)).toEqual(true);
   });
+
+  it('should not contain <title> when the "help" icon is used', () => {
+    const component = shallow(
+      <Icon
+        name="help"
+      />);
+    expect(component.contains(<title>help</title>)).toEqual(false);
+  });
   //
 
   // const component = shallow(<Icon name='bell' />)


### PR DESCRIPTION
**Summary:**
As discussed in https://optimizely.slack.com/archives/C03DQJA7D/p1531418787000064, this will remove an unwanted tooltip from the svg when the "Help" Icon is used. This was being caused by the title element from the svg.

**Screenshot (before tooltip removed):**
![image](https://user-images.githubusercontent.com/7128855/42651596-b2d31620-85c4-11e8-9c64-4b829cabdb6f.png)
