### PR TITLE
[FE-900] Fix ES module build of react-oui-icons not transpiling JSX

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,16 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": [
+    ["env", { "modules": false }],
+    "react"
+  ],
+  "env": {
+    "test": {
+      "presets": [["env"], "react"],
+      "plugins": [
+        ["inline-json-import", {}]
+      ]
+    }
+  },
   "plugins": [
     ["inline-json-import", {}]
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 node_modules
 coverage
 dist
+module
 storybook-static
 
 .DS_Store
 .env
 npm-debug.log*
-yarn-debug.log*
+yarn-error.log*
 yarn.lock
 
 src/.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ config
 node_modules
 scripts
 stories
+src
 
 yarn.lock
 
@@ -11,4 +12,4 @@ yarn.lock
 
 *tests.js
 npm-debug.log*
-yarn-debug.log*
+yarn-error.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file is similar to the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## Unreleased
+- [Feature] Fix ES module build of react-oui-icons not transpiling JSX
 
 ## 2.4.0 - 2018-10-22
 - [Feature] Add comments icon

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @optimizely/frontend @optimizely/ui-engineers

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-oui-icons",
   "version": "2.4.0",
   "main": "dist/index.js",
-  "module": "src/index.js",
+  "module": "module/index.js",
   "private": false,
   "repository": {
     "type": "git",
@@ -33,8 +33,9 @@
   ],
   "license": "ISC",
   "scripts": {
-    "build": "npm run babel && gulp svg:combined",
-    "babel": "babel ./src --ignore *test.js --out-dir ./dist",
+    "build": "npm run babel-es5 && npm run babel-module && gulp svg:combined",
+    "babel-es5": "babel ./src --ignore *test.js --out-dir ./dist --presets=env,react --plugins=inline-json-import",
+    "babel-module": "babel ./src --ignore *test.js --out-dir ./module",
     "test": "node scripts/test.js --env=jsdom",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
- changed .babelrc to reflect the ES module build being the primary build of OUI, legacy ES5 build now made the special case
  - this change required defining a "test" babel env in .babelrc to ensure that the jest build DOES transpile the ES modules to commonjs
- ES module build now built into `/module` and configured so that JSX is properly transpiled
  - .gitignore and .npmignore updated to reflect this change
- package.json esmodule index path adjusted
- See associated OUI PR: https://github.com/optimizely/oui/pull/1073