### PR TITLE
docs: update docs to prefer yarn and more details for release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Icons for the Optimizely application and other OUI projects.
 
 This implementation consists of a Icon React Component that will generate an inline SVG icon using the data associated with the name of the icon. Any attributes will be passed as props.
 
-
 [View all the icons](https://github.com/optimizely/react-oui-icons).
 
 ## Using the icons
@@ -35,7 +34,7 @@ This implementation consists of a Icon React Component that will generate an inl
 ## Storybook
 `react-oui-icons` uses [Storybook](https://storybook.js.org/)! You can view all of the icons through the Storybook interface by running:
 
-```
+```sh
 yarn run storybook
 ```
 
@@ -50,12 +49,29 @@ It will start a local webserver served at `http://localhost:6006/`.
 ## Test in Optimizely.git
 
 1. `cd ~/react-oui-icons`
-2. `npm link`
+2. `yarn link`
 3. `cd ~/optimizely`
-4. `npm link react-oui-icons`
+4. `yarn link react-oui-icons`
 5. Use `?use_local_bundle=true` to test your icon changes before releasing with confidence
 
+## :warning: Pre-Release
+
+Don't forget these before you create a release:
+
+1. Add a new header to `CHANGELOG.md` under “Unreleased” with the [new version number](https://medium.com/design-optimizely/how-to-version-your-ui-library-1c7a1b7ee23a):
+
+    ```md
+    ## Unreleased
+
+    ## 2.0.0 - 2018-04-13
+    - [Release] Added a cool breaking change. (#999)
+    ```
+2. Commit to master: `git add . && git commit -a -m 'Prep for new release version x.y.z'`
+
 ## Release new version of react-oui-icons
-1. Commit changes, push, create PR, get approval, squash & merge...
-2. `npm run release patch` or `npm run release minor` or `npm run release major`
-3. OUI will automatically bump the react-oui-icons `^0.0.x` releases, so you will need to create a new release of OUI if your icon changes include minor or major changes.
+
+1. `yarn release patch` or `yarn release minor` or `yarn release major`
+2. [Create a new release on GitHub](https://github.com/optimizely/react-oui-icons/releases/new):
+    * Select the new tag version
+    * Leave “Release title” blank
+    * Paste in “Unreleased” latest additions from the `CHANGELOG.md` release notes


### PR DESCRIPTION
README update:
- prefer `yarn link` and `yarn release`
- pull release steps from OUI docs to fill in some gaps here in that documentation