### PR TITLE
Improve Storybook readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is similar to the format suggested by [Keep a CHANGELOG](https://githu
 
 ## Unreleased
 
+- [Fix] Improve readability of icons and icon titles in Storybook
+
 ## 2.5.0 - 2018-10-29
 - [Feature] Fix ES module build of react-oui-icons not transpiling JSX
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,8 +15,8 @@ const Container = styled.div`
 const styles = {
   icon: {
     alignSelf: "center",
-    width: 32,
-    height: 32,
+    width: 24,
+    height: 24,
   }
 }
 
@@ -42,7 +42,7 @@ stories.add('All icons', withInfo()(() => {
           transition: all 0.4s ease;
           content: '${icon.title}';
           font-family: Helvetica;
-          font-size: 16px;
+          font-size: 14px;
           position: absolute;
           bottom: 30px;
         }

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,6 +15,8 @@ const Container = styled.div`
 const styles = {
   icon: {
     alignSelf: "center",
+    width: 32,
+    height: 32,
   }
 }
 
@@ -40,7 +42,7 @@ stories.add('All icons', withInfo()(() => {
           transition: all 0.4s ease;
           content: '${icon.title}';
           font-family: Helvetica;
-          font-size: 10px;
+          font-size: 16px;
           position: absolute;
           bottom: 30px;
         }


### PR DESCRIPTION
## Summary

The icons and icon titles in this repo's Storybook are difficult to read. Proposing to increase the size of both to make it easier to find what you're looking for!

**Before**
![screen shot 2019-02-20 at 11 46 23 am](https://user-images.githubusercontent.com/10509704/53113155-84775600-3506-11e9-821e-f01daa801ef6.png)

**After**
![screen shot 2019-02-20 at 11 47 33 am](https://user-images.githubusercontent.com/10509704/53113161-87724680-3506-11e9-9d55-87d1356ef12b.png)
